### PR TITLE
Bump ghcup to 0.1.12

### DIFF
--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -11188,7 +11188,7 @@ async function choco(tool, version) {
     }
 }
 async function ghcupBin(os) {
-    const v = '0.1.8';
+    const v = '0.1.12';
     const cachedBin = tc.find('ghcup', v);
     if (cachedBin)
         return path_1.join(cachedBin, 'ghcup');

--- a/setup/src/installer.ts
+++ b/setup/src/installer.ts
@@ -188,7 +188,7 @@ async function choco(tool: Tool, version: string): Promise<void> {
 }
 
 async function ghcupBin(os: OS): Promise<string> {
-  const v = '0.1.8';
+  const v = '0.1.12';
   const cachedBin = tc.find('ghcup', v);
   if (cachedBin) return join(cachedBin, 'ghcup');
 


### PR DESCRIPTION
I am experimenting right now to use setup-haskell for the Haddock's ghc-head branch. Currently my attempt fails with 

```
  Attempting to install ghc 9.0.0.20200925 using ghcup
  /opt/hostedtoolcache/ghcup/0.1.8/x64/ghcup install 9.0.0.20200925
  [ Warn  ] New GHCup version available: 0.1.9. To upgrade, run 'ghcup upgrade'
  [ Warn  ] This is an old-style command for installing GHC. Use 'ghcup install ghc' instead.
  [ Error ] No available GHC version for 9.0.0.20200925
```

I am proposing this change in the hope that it helps.. Feel free to ignore. 