### PR TITLE
Check more versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,8 +37,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         ghc: ["latest", "8.4.4"]
-        cabal: ["latest"]
+        cabal: ["latest", "3.2.0.0", "3.4.0.0-rc4"]
         expect-fail: [false]
+        exclude:
+          - os: windows-latest
+            cabal: "3.4.0.0-rc4"
         include:
           - os: ubuntu-latest
             ghc: "7.10.3"


### PR DESCRIPTION
Additionally check that `cabal-3.2.0.0` and `3.4.0.0-rc4` work.

This is related to https://github.com/haskell/actions/issues/15.

Specifically that `3.4.0.0-rc4` installs the wrong version.

There is no assertion that the correct version is installed, but it can be see in the CI output that the wrong version is installed when `3.4.0.0-rc4` is added.