### PR TITLE
Fix macos cabal 3.4.0.0 rc4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,8 +37,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         ghc: ["latest", "8.4.4"]
-        cabal: ["latest"]
+        cabal: ["latest", "3.2.0.0", "3.4.0.0-rc4"]
         expect-fail: [false]
+        exclude:
+          - os: windows-latest
+            cabal: "3.4.0.0-rc4"
         include:
           - os: ubuntu-latest
             ghc: "7.10.3"

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -11249,7 +11249,7 @@ async function isInstalled(tool, version, os) {
     }
     if (tool === 'cabal' && os !== 'win32') {
         const installedPath = await fs_1.promises
-            .access(`${ghcupPath}/cabal`)
+            .access(`${ghcupPath}/cabal-${version}`)
             .then(() => ghcupPath)
             .catch(() => undefined);
         if (installedPath) {

--- a/setup/lib/installer.js
+++ b/setup/lib/installer.js
@@ -100,7 +100,7 @@ async function isInstalled(tool, version, os) {
     }
     if (tool === 'cabal' && os !== 'win32') {
         const installedPath = await fs_1.promises
-            .access(`${ghcupPath}/cabal`)
+            .access(`${ghcupPath}/cabal-${version}`)
             .then(() => ghcupPath)
             .catch(() => undefined);
         if (installedPath) {

--- a/setup/src/installer.ts
+++ b/setup/src/installer.ts
@@ -111,7 +111,7 @@ async function isInstalled(
 
   if (tool === 'cabal' && os !== 'win32') {
     const installedPath = await fs
-      .access(`${ghcupPath}/cabal`)
+      .access(`${ghcupPath}/cabal-${version}`)
       .then(() => ghcupPath)
       .catch(() => undefined);
 


### PR DESCRIPTION
This ensures that `cabal-3.4.0.0-rc4` can be installed on MacOS

![image](https://user-images.githubusercontent.com/63014/102759508-53009780-43c8-11eb-9841-92c543621705.png)
