### PR TITLE
Add a problem matcher for GHC errors

### DIFF
--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -8802,6 +8802,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const fs = __importStar(__webpack_require__(747));
+const path = __importStar(__webpack_require__(622));
 const opts_1 = __webpack_require__(54);
 const installer_1 = __webpack_require__(923);
 const exec_1 = __webpack_require__(986);
@@ -8838,6 +8839,7 @@ async function run(inputs) {
                 if (!opts.stack.enable)
                     await exec_1.exec('cabal update');
             });
+        core.info(`##[add-matcher]${path.join(__dirname, '..', 'matcher.json')}`);
     }
     catch (error) {
         core.setFailed(error.message);

--- a/setup/lib/setup-haskell.js
+++ b/setup/lib/setup-haskell.js
@@ -21,6 +21,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const fs = __importStar(require("fs"));
+const path = __importStar(require("path"));
 const opts_1 = require("./opts");
 const installer_1 = require("./installer");
 const exec_1 = require("@actions/exec");
@@ -57,6 +58,7 @@ async function run(inputs) {
                 if (!opts.stack.enable)
                     await exec_1.exec('cabal update');
             });
+        core.info(`##[add-matcher]${path.join(__dirname, '..', 'matcher.json')}`);
     }
     catch (error) {
         core.setFailed(error.message);

--- a/setup/matcher.json
+++ b/setup/matcher.json
@@ -1,0 +1,20 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "haskell",
+      "pattern": [
+        {
+          "regexp": "^(.+\\.hs):(\\d+):(\\d+): (\\w+):",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4
+        },
+        {
+          "regexp": "^    (.*)$",
+          "message": 1
+        }
+      ]
+    }
+  ]
+}

--- a/setup/src/setup-haskell.ts
+++ b/setup/src/setup-haskell.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core';
 import * as fs from 'fs';
+import * as path from 'path';
 import {getOpts, getDefaults, Tool} from './opts';
 import {installTool} from './installer';
 import type {OS} from './opts';
@@ -48,6 +49,8 @@ export default async function run(
         await exec('cabal user-config update');
         if (!opts.stack.enable) await exec('cabal update');
       });
+
+    core.info(`##[add-matcher]${path.join(__dirname, '..', 'matcher.json')}`);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
Allows for errors and warnings to be reported as annotations:

<img width="855" alt="image" src="https://user-images.githubusercontent.com/2488460/106695980-a410c780-65d3-11eb-8ade-cfff71fbf8e3.png">

One limitation is that there doesn't seem to be support for matching a message field with multiple lines, so this just reports the first line of the error message