### PR TITLE
Checks versions in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,7 +46,7 @@ jobs:
             expect-fail: false
           - os: ubuntu-latest
             ghc: "8.2.2"
-            cabal: "2.0"
+            cabal: "2.4.0.1"
             expect-fail: false
           - os: ubuntu-latest
             ghc: "8.12.0" # A version that will never exist.
@@ -72,9 +72,10 @@ jobs:
         run: cabal run
         continue-on-error: ${{ matrix.expect-fail }}
       - name: Check installed versions
+        shell: bash
         run: |
-          cabal --version
-          ghc --version
+          [[ "$(cabal --numeric-version)" == "${{ matrix.cabal }}" ]]
+          [[ "$(ghc --numeric-version)" == "${{ matrix.ghc }}" ]]
         continue-on-error: ${{ matrix.expect-fail }}
       - name: Confirm GHC version
         shell: bash

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.expect-fail }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         ghc: ["latest", "8.4.4"]
@@ -54,7 +54,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./setup
-        continue-on-error: ${{ matrix.expect-fail }}
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
@@ -62,28 +61,25 @@ jobs:
         run: |
           runhaskell --version
           runhaskell __tests__/hello.hs
-        continue-on-error: ${{ matrix.expect-fail }}
       - name: Build test project
         working-directory: setup/__tests__/project
         run: cabal build
-        continue-on-error: ${{ matrix.expect-fail }}
       - name: Run test project
         working-directory: setup/__tests__/project
         run: cabal run
-        continue-on-error: ${{ matrix.expect-fail }}
-      - name: Check installed versions
-        shell: bash
+      - name: Show installed versions
         run: |
-          [[ "$(cabal --numeric-version)" == "${{ matrix.cabal }}" ]]
-          [[ "$(ghc --numeric-version)" == "${{ matrix.ghc }}" ]]
-        continue-on-error: ${{ matrix.expect-fail }}
-      - name: Confirm GHC version
+          cabal --version
+          ghc --version
+      - name: Confirm installed and expected versions match
         shell: bash
-        continue-on-error: ${{ matrix.expect-fail }}
-        if: matrix.ghc != 'latest'
         # this check depends on the ghc versions being "exact" in the matrix
+        if: "matrix.ghc != 'latest' && matrix.ghc != '8.12.0'"
+        # pure bash startsWith
         run: |
-          [[ $(ghc --numeric-version) == "${{ matrix.ghc }}" ]]
+          [[ "${{ matrix.cabal }}" =~ ^([0-9]+\.[0-9]+)\. ]] && ver="${BASH_REMATCH[1]}"
+          [[ "$(cabal --numeric-version)" =~ ^"$ver" ]]
+          [[ "$(ghc --numeric-version)" == "${{ matrix.ghc }}" ]]
 
   install-stack:
     name: Stack ${{ matrix.stack }} ${{ matrix.os }}

--- a/setup/README.md
+++ b/setup/README.md
@@ -157,8 +157,6 @@ Suggestion: Try to support the three latest major versions of GHC.
 - `3.2.0.0` `3.2`
 - `3.0.0.0` `3.0`
 - `2.4.1.0` `2.4`
-- `2.4.0.0`
-- `2.2.0.0` `2.2`
 
 Recommendation: Use the latest available version if possible.
 

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -11222,7 +11222,7 @@ function warn(tool, version) {
         ghc: `the three latest major releases of ${tool} are commonly supported.`,
         stack: `the latest release of ${tool} is commonly supported.`
     }[tool];
-    core.warning(`${tool} ${version} was not found in the cache. It will be downloaded.\n` +
+    core.debug(`${tool} ${version} was not found in the cache. It will be downloaded.\n` +
         `If this is unexpected, please check if version ${version} is pre-installed.\n` +
         `The list of pre-installed versions is available here: https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners\n` +
         `The above list follows a common haskell convention that ${policy}\n` +

--- a/setup/lib/installer.js
+++ b/setup/lib/installer.js
@@ -60,7 +60,7 @@ function warn(tool, version) {
         ghc: `the three latest major releases of ${tool} are commonly supported.`,
         stack: `the latest release of ${tool} is commonly supported.`
     }[tool];
-    core.warning(`${tool} ${version} was not found in the cache. It will be downloaded.\n` +
+    core.debug(`${tool} ${version} was not found in the cache. It will be downloaded.\n` +
         `If this is unexpected, please check if version ${version} is pre-installed.\n` +
         `The list of pre-installed versions is available here: https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners\n` +
         `The above list follows a common haskell convention that ${policy}\n` +

--- a/setup/package.json
+++ b/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-haskell",
-  "version": "1.1.8",
+  "version": "1.2.1",
   "private": true,
   "description": "setup haskell action",
   "main": "lib/setup-haskell",

--- a/setup/src/installer.ts
+++ b/setup/src/installer.ts
@@ -54,7 +54,7 @@ function warn(tool: Tool, version: string): void {
     stack: `the latest release of ${tool} is commonly supported.`
   }[tool];
 
-  core.warning(
+  core.debug(
     `${tool} ${version} was not found in the cache. It will be downloaded.\n` +
       `If this is unexpected, please check if version ${version} is pre-installed.\n` +
       `The list of pre-installed versions is available here: https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners\n` +


### PR DESCRIPTION
Bumps relevant versions and checks versions better in CI so that I can catch mismatches between installed versions and desired versions easier.

This should, hopefully, be the last release that's not automated.

Closes:
- #46 