### PR TITLE
Repair support for older versions of Cabal

### DIFF
--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -11229,12 +11229,17 @@ function warn(tool, version) {
         'If the list is outdated, please file an issue here: https://github.com/actions/virtual-environments\n' +
         'by using the appropriate tool request template: https://github.com/actions/virtual-environments/issues/new/choose');
 }
+function aptVersion(tool, version) {
+    // For Cabal, extract the first two segments of the version number. This
+    // regex is intentionally liberal to accomodate unusual cases like "head".
+    return tool === 'cabal' ? /[^.]*\.?[^.]*/.exec(version)[0] : version;
+}
 async function isInstalled(tool, version, os) {
     const toolPath = tc.find(tool, version);
     if (toolPath)
         return success(tool, version, toolPath, os);
     const ghcupPath = `${process_1.default.env.HOME}/.ghcup${tool === 'ghc' ? `/ghc/${version}` : ''}/bin`;
-    const v = tool === 'cabal' ? version.slice(0, 3) : version;
+    const v = aptVersion(tool, version);
     const aptPath = `/opt/${tool}/${v}/bin`;
     const chocoPath = await getChocoPath(tool, version);
     const locations = {
@@ -11322,7 +11327,7 @@ async function stack(version, os) {
 }
 async function apt(tool, version) {
     const toolName = tool === 'ghc' ? 'ghc' : 'cabal-install';
-    const v = tool === 'cabal' ? version.slice(0, 3) : version;
+    const v = aptVersion(tool, version);
     core.info(`Attempting to install ${toolName} ${v} using apt-get`);
     // Ignore the return code so we can fall back to ghcup
     await exec(`sudo -- sh -c "apt-get -y install ${toolName}-${v}"`);

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -8829,16 +8829,16 @@ async function run(inputs) {
             await core.group('Pre-installing GHC with stack', async () => exec_1.exec('stack', ['setup', opts.ghc.resolved]));
         if (opts.cabal.enable)
             await core.group('Setting up cabal', async () => {
-                await exec_1.exec('cabal', ['user-config', 'update'], { silent: true });
-                const configFile = await cabalConfig();
                 if (process.platform === 'win32') {
+                    await exec_1.exec('cabal', ['user-config', 'update'], { silent: true });
+                    const configFile = await cabalConfig();
                     fs.appendFileSync(configFile, 'store-dir: C:\\sr\n');
                     core.setOutput('cabal-store', 'C:\\sr');
+                    await exec_1.exec('cabal user-config update');
                 }
                 else {
                     core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
                 }
-                await exec_1.exec('cabal user-config update');
                 if (!opts.stack.enable)
                     await exec_1.exec('cabal update');
             });

--- a/setup/lib/installer.js
+++ b/setup/lib/installer.js
@@ -67,12 +67,17 @@ function warn(tool, version) {
         'If the list is outdated, please file an issue here: https://github.com/actions/virtual-environments\n' +
         'by using the appropriate tool request template: https://github.com/actions/virtual-environments/issues/new/choose');
 }
+function aptVersion(tool, version) {
+    // For Cabal, extract the first two segments of the version number. This
+    // regex is intentionally liberal to accomodate unusual cases like "head".
+    return tool === 'cabal' ? /[^.]*\.?[^.]*/.exec(version)[0] : version;
+}
 async function isInstalled(tool, version, os) {
     const toolPath = tc.find(tool, version);
     if (toolPath)
         return success(tool, version, toolPath, os);
     const ghcupPath = `${process_1.default.env.HOME}/.ghcup${tool === 'ghc' ? `/ghc/${version}` : ''}/bin`;
-    const v = tool === 'cabal' ? version.slice(0, 3) : version;
+    const v = aptVersion(tool, version);
     const aptPath = `/opt/${tool}/${v}/bin`;
     const chocoPath = await getChocoPath(tool, version);
     const locations = {
@@ -160,7 +165,7 @@ async function stack(version, os) {
 }
 async function apt(tool, version) {
     const toolName = tool === 'ghc' ? 'ghc' : 'cabal-install';
-    const v = tool === 'cabal' ? version.slice(0, 3) : version;
+    const v = aptVersion(tool, version);
     core.info(`Attempting to install ${toolName} ${v} using apt-get`);
     // Ignore the return code so we can fall back to ghcup
     await exec(`sudo -- sh -c "apt-get -y install ${toolName}-${v}"`);

--- a/setup/lib/setup-haskell.js
+++ b/setup/lib/setup-haskell.js
@@ -45,16 +45,16 @@ async function run(inputs) {
             await core.group('Pre-installing GHC with stack', async () => exec_1.exec('stack', ['setup', opts.ghc.resolved]));
         if (opts.cabal.enable)
             await core.group('Setting up cabal', async () => {
-                await exec_1.exec('cabal', ['user-config', 'update'], { silent: true });
-                const configFile = await cabalConfig();
                 if (process.platform === 'win32') {
+                    await exec_1.exec('cabal', ['user-config', 'update'], { silent: true });
+                    const configFile = await cabalConfig();
                     fs.appendFileSync(configFile, 'store-dir: C:\\sr\n');
                     core.setOutput('cabal-store', 'C:\\sr');
+                    await exec_1.exec('cabal user-config update');
                 }
                 else {
                     core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
                 }
-                await exec_1.exec('cabal user-config update');
                 if (!opts.stack.enable)
                     await exec_1.exec('cabal update');
             });

--- a/setup/src/installer.ts
+++ b/setup/src/installer.ts
@@ -64,6 +64,12 @@ function warn(tool: Tool, version: string): void {
   );
 }
 
+function aptVersion(tool: string, version: string): string {
+  // For Cabal, extract the first two segments of the version number. This
+  // regex is intentionally liberal to accomodate unusual cases like "head".
+  return tool === 'cabal' ? /[^.]*\.?[^.]*/.exec(version)![0] : version;
+}
+
 async function isInstalled(
   tool: Tool,
   version: string,
@@ -75,7 +81,7 @@ async function isInstalled(
   const ghcupPath = `${process.env.HOME}/.ghcup${
     tool === 'ghc' ? `/ghc/${version}` : ''
   }/bin`;
-  const v = tool === 'cabal' ? version.slice(0, 3) : version;
+  const v = aptVersion(tool, version);
   const aptPath = `/opt/${tool}/${v}/bin`;
 
   const chocoPath = await getChocoPath(tool, version);
@@ -177,7 +183,7 @@ async function stack(version: string, os: OS): Promise<void> {
 
 async function apt(tool: Tool, version: string): Promise<void> {
   const toolName = tool === 'ghc' ? 'ghc' : 'cabal-install';
-  const v = tool === 'cabal' ? version.slice(0, 3) : version;
+  const v = aptVersion(tool, version);
   core.info(`Attempting to install ${toolName} ${v} using apt-get`);
   // Ignore the return code so we can fall back to ghcup
   await exec(`sudo -- sh -c "apt-get -y install ${toolName}-${v}"`);

--- a/setup/src/setup-haskell.ts
+++ b/setup/src/setup-haskell.ts
@@ -36,17 +36,16 @@ export default async function run(
 
     if (opts.cabal.enable)
       await core.group('Setting up cabal', async () => {
-        await exec('cabal', ['user-config', 'update'], {silent: true});
-        const configFile = await cabalConfig();
-
         if (process.platform === 'win32') {
+          await exec('cabal', ['user-config', 'update'], {silent: true});
+          const configFile = await cabalConfig();
           fs.appendFileSync(configFile, 'store-dir: C:\\sr\n');
           core.setOutput('cabal-store', 'C:\\sr');
+          await exec('cabal user-config update');
         } else {
           core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
         }
 
-        await exec('cabal user-config update');
         if (!opts.stack.enable) await exec('cabal update');
       });
 


### PR DESCRIPTION
These two fixes are needed to make *haskell/actions/setup* support older (1.*) versions of Cabal on Ubuntu.

(Rationale: In trying to port https://github.com/haskell/directory from Travis CI to GitHub Actions, these older Cabal versions are needed to maintain the same coverage matrix.)