### PR TITLE
Add parse-cabal-file action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A Collection of GitHub actions for interacting with Haskell.
 
-| Action                                         |
-| ----------------------------------             |
-| [`haskell/actions/setup`](./setup)             |
-| [`haskell/actions/hlint-setup`](./hlint-setup) |
-| [`haskell/actions/hlint-run`](./hlint-run)     |
-|                                                |
+| Action                                                   |
+|----------------------------------------------------------|
+| [`haskell/actions/setup`](./setup)                       |
+| [`haskell/actions/hlint-setup`](./hlint-setup)           |
+| [`haskell/actions/hlint-run`](./hlint-run)               |
+| [`haskell/actions/parse-cabal-file`](./parse-cabal-file) |
 
 See the individual action directory for details on usage and examples.

--- a/parse-cabal-file/.github/workflows/test.yml
+++ b/parse-cabal-file/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: parse-cabal-file
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'releases/*'
+
+defaults:
+  run:
+    working-directory: parse-cabal-file
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ghc -Wall -Werror ParseCabalFile.hs
+      - uses: fourmolu/fourmolu-action@v1
+        with:
+          pattern: parse-cabal-file/**/*.hs
+          extra-args: >
+            --indentation 2
+            --indent-wheres true

--- a/parse-cabal-file/ParseCabalFile.hs
+++ b/parse-cabal-file/ParseCabalFile.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+
+import Data.ByteString qualified as BS
+import Data.List (intercalate)
+import Distribution.Package (packageVersion)
+import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
+import Distribution.Verbosity qualified as Verbosity
+import Distribution.Version (versionNumbers)
+import System.Environment (getArgs)
+import System.IO (hPutStrLn, stderr, stdout)
+
+main :: IO ()
+main = do
+  cabalFile <-
+    getArgs >>= \case
+      [cabalFile] -> return cabalFile
+      _ -> errorWithoutStackTrace "Expected exactly one argument: CABAL_FILE"
+
+  cabalFileContents <- BS.readFile cabalFile
+  packageDesc <-
+    maybe (errorWithoutStackTrace "Could not parse cabal file") return $
+      parseGenericPackageDescriptionMaybe cabalFileContents
+
+  output
+    [ ("version", intercalate "." . map show . versionNumbers . packageVersion $ packageDesc)
+    ]
+
+output :: [(String, String)] -> IO ()
+output = mapM_ (uncurry output')
+  where
+    output' key value = do
+      let kv = key ++ "=" ++ value
+      -- log to stderr
+      hPutStrLn stderr $ "Setting: " ++ kv
+      -- output to stdout into $GITHUB_OUTPUT
+      hPutStrLn stdout kv

--- a/parse-cabal-file/README.md
+++ b/parse-cabal-file/README.md
@@ -1,0 +1,34 @@
+# parse-cabal-file
+
+GitHub Action: Parse Cabal file
+
+## Inputs
+
+* `cabal_file` (required): The path to a cabal file
+
+## Outputs
+
+* `version`: The version in the Cabal file
+
+## Example
+
+```yaml
+name: Release
+on:
+  push:
+    branches:
+      - 'releases/*'
+
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: haskell/actions/parse-cabal-file@main
+      id: cabal_file
+      with:
+        cabal_file: my-library.cabal
+
+    - run: echo ${{ steps.cabal_file.outputs.version }}
+```

--- a/parse-cabal-file/action.yml
+++ b/parse-cabal-file/action.yml
@@ -1,0 +1,23 @@
+name: Parse Cabal File
+description: Parse information in a provided cabal file
+
+inputs:
+  cabal_file:
+    description: Path to cabal file
+    required: true
+
+outputs:
+  version:
+    description: The version in the cabal file
+    value: ${{ steps.cabal_file.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - run: |
+        BINDIR=${GITHUB_ACTION_PATH}/bin
+        mkdir -p ${BINDIR}
+        ghc ${GITHUB_ACTION_PATH}/ParseCabalFile.hs -outputdir /tmp -o ${BINDIR}/parse-cabal-file
+        ${BINDIR}/parse-cabal-file "${{ inputs.cabal_file }}" >> "${GITHUB_OUTPUT}"
+      id: cabal_file
+      shell: bash


### PR DESCRIPTION
Another useful utility broken out from other projects. Currently only outputs the version in the cabal file, but it's easily extendable to add more Cabal fields.

Currently, it's built with `ghc` on-demand. Since `ghc` comes provided with GitHub runners, this should be sufficient for most use-cases. In the future, it could be worthwhile to do this properly (e.g. build in CI, put binaries in release assets, download binaries based on runner OS, ...) but this should work for now