### PR TITLE
Fix #128: bump hlint default version to 3.5

### DIFF
--- a/hlint-setup/README.md
+++ b/hlint-setup/README.md
@@ -1,12 +1,10 @@
 # hlint-setup
 
-GitHub Action: Set up hlint
+GitHub Action: Set up `hlint`.
 
-Downloads a binary of HLint from [@ndmitchell/hlint](https://github.com/ndmitchell/hlint).
-
-The which gets cached through [@actions/tool-cache](https://github.com/actions/tool-cache)
-
-And adds it into `PATH`.
+Downloads a binary of HLint from [@ndmitchell/hlint](https://github.com/ndmitchell/hlint),
+caches it through [@actions/tool-cache](https://github.com/actions/tool-cache),
+and adds it into `PATH`.
 
 See also [haskell/actions/hlint-run](https://github.com/haskell/actions/tree/main/hlint-run), which will run `hlint` and represent its output in GitHub annotations.
 
@@ -16,9 +14,9 @@ See also [haskell/actions/hlint-run](https://github.com/haskell/actions/tree/mai
 
 ## Outputs
 
-* `hlint-dir`: Resulting directory containing the `hlint` executable
-* `hlint-bin`: Location of the `hlint` executable
-* `version`: Version of the `hlint` tool (same as input, if provided)
+* `hlint-dir`: Resulting directory containing the `hlint` executable.
+* `hlint-bin`: Location of the `hlint` executable.
+* `version`: Version of the `hlint` tool (same as input, if provided).
 
 ## Example
 

--- a/hlint-setup/README.md
+++ b/hlint-setup/README.md
@@ -10,7 +10,10 @@ See also [haskell/actions/hlint-run](https://github.com/haskell/actions/tree/mai
 
 ## Inputs
 
-* `version`: The HLint version to download. Currently defaults to `3.1.6`.
+* `version`: The HLint version to download. Currently defaults to `3.5`.
+
+  Note that on some virtual environments, some versions of `hlint` need extra prerequisites installed.
+  E.g., on `ubuntu-22.04`, versions `hlint < 3.5` need the `libncurses5` library ([#128](https://github.com/haskell/actions/issues/128)).
 
 ## Outputs
 

--- a/hlint-setup/action.yml
+++ b/hlint-setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'hlint version'
     required: false
-    default: '3.3.6'
+    default: '3.5'
 outputs:
   hlint-dir:
     description: 'Directory containing the hlint executable'


### PR DESCRIPTION
Fix #128: bump hlint default version to 3.5