### PR TITLE
Fix #144: include <tool> in 'Resolved' info

### DIFF
--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13667,12 +13667,17 @@ function getDefaults(os) {
     };
 }
 exports.getDefaults = getDefaults;
+// Side effect: if resolution isn't the identity, print what resolved to what.
 function resolve(version, supported, tool, os) {
     const resolved = version === 'latest'
         ? supported[0]
         : supported.find(v => v.startsWith(version)) ?? version;
-    return (exports.release_revisions?.[os]?.[tool]?.find(({ from }) => from === resolved)?.to ??
-        resolved);
+    const result = exports.release_revisions?.[os]?.[tool]?.find(({ from }) => from === resolved)?.to ??
+        resolved;
+    // Andreas 2022-12-29, issue #144: inform about resolution here where we can also output ${tool}.
+    if (version !== result)
+        core.info(`Resolved ${tool} ${version} to ${result}`);
+    return result;
 }
 function getOpts({ ghc, cabal, stack }, os, inputs) {
     core.debug(`Inputs are: ${JSON.stringify(inputs)}`);
@@ -13715,10 +13720,10 @@ function getOpts({ ghc, cabal, stack }, os, inputs) {
         },
         general: { matcher: { enable: !matcherDisable } }
     };
-    // eslint-disable-next-line github/array-foreach
-    Object.values(opts)
-        .filter(t => t.enable && t.raw !== t.resolved)
-        .forEach(t => core.info(`Resolved ${t.raw} to ${t.resolved}`));
+    // // eslint-disable-next-line github/array-foreach
+    // Object.values(opts)
+    //   .filter(t => t.enable && t.raw !== t.resolved)
+    //   .forEach(t => core.info(`Resolved ${t.raw} to ${t.resolved}`));
     core.debug(`Options are: ${JSON.stringify(opts)}`);
     return opts;
 }

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13702,20 +13702,25 @@ function getOpts({ ghc, cabal, stack }, os, inputs) {
     if (errors.length > 0) {
         throw new Error(errors.join('\n'));
     }
+    const ghcEnable = !stackNoGlobal;
+    const cabalEnable = !stackNoGlobal;
     const opts = {
         ghc: {
             raw: verInpt.ghc,
-            resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os, true),
-            enable: !stackNoGlobal
+            resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os, ghcEnable // if true: inform user about resolution
+            ),
+            enable: ghcEnable
         },
         cabal: {
             raw: verInpt.cabal,
-            resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os, true),
-            enable: !stackNoGlobal
+            resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os, cabalEnable // if true: inform user about resolution
+            ),
+            enable: cabalEnable
         },
         stack: {
             raw: verInpt.stack,
-            resolved: resolve(verInpt.stack, stack.supported, 'stack', os, true),
+            resolved: resolve(verInpt.stack, stack.supported, 'stack', os, stackEnable // if true: inform user about resolution
+            ),
             enable: stackEnable,
             setup: stackSetupGhc
         },

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13676,7 +13676,7 @@ function resolve(version, supported, tool, os, verbose // If resolution isn't th
     const result = exports.release_revisions?.[os]?.[tool]?.find(({ from }) => from === resolved)?.to ??
         resolved;
     // Andreas 2022-12-29, issue #144: inform about resolution here where we can also output ${tool}.
-    if (verbose && version !== result)
+    if (verbose === true && version !== result)
         core.info(`Resolved ${tool} ${version} to ${result}`);
     return result;
 }

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13656,7 +13656,7 @@ exports.yamlInputs = (0, js_yaml_1.load)((0, fs_1.readFileSync)((0, path_1.join)
 ).inputs;
 function getDefaults(os) {
     const mkVersion = (v, vs, t) => ({
-        version: resolve(exports.yamlInputs[v].default, vs, t, os),
+        version: resolve(exports.yamlInputs[v].default, vs, t, os, false),
         supported: vs
     });
     return {
@@ -13667,15 +13667,16 @@ function getDefaults(os) {
     };
 }
 exports.getDefaults = getDefaults;
-// Side effect: if resolution isn't the identity, print what resolved to what.
-function resolve(version, supported, tool, os) {
+// E.g. resolve ghc latest to 9.4.2
+function resolve(version, supported, tool, os, verbose // If resolution isn't the identity, print what resolved to what.
+) {
     const resolved = version === 'latest'
         ? supported[0]
         : supported.find(v => v.startsWith(version)) ?? version;
     const result = exports.release_revisions?.[os]?.[tool]?.find(({ from }) => from === resolved)?.to ??
         resolved;
     // Andreas 2022-12-29, issue #144: inform about resolution here where we can also output ${tool}.
-    if (version !== result)
+    if (verbose && version !== result)
         core.info(`Resolved ${tool} ${version} to ${result}`);
     return result;
 }
@@ -13704,26 +13705,22 @@ function getOpts({ ghc, cabal, stack }, os, inputs) {
     const opts = {
         ghc: {
             raw: verInpt.ghc,
-            resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os),
+            resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os, true),
             enable: !stackNoGlobal
         },
         cabal: {
             raw: verInpt.cabal,
-            resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os),
+            resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os, true),
             enable: !stackNoGlobal
         },
         stack: {
             raw: verInpt.stack,
-            resolved: resolve(verInpt.stack, stack.supported, 'stack', os),
+            resolved: resolve(verInpt.stack, stack.supported, 'stack', os, true),
             enable: stackEnable,
             setup: stackSetupGhc
         },
         general: { matcher: { enable: !matcherDisable } }
     };
-    // // eslint-disable-next-line github/array-foreach
-    // Object.values(opts)
-    //   .filter(t => t.enable && t.raw !== t.resolved)
-    //   .forEach(t => core.info(`Resolved ${t.raw} to ${t.resolved}`));
     core.debug(`Options are: ${JSON.stringify(opts)}`);
     return opts;
 }

--- a/setup/lib/opts.js
+++ b/setup/lib/opts.js
@@ -39,7 +39,7 @@ exports.yamlInputs = (0, js_yaml_1.load)((0, fs_1.readFileSync)((0, path_1.join)
 ).inputs;
 function getDefaults(os) {
     const mkVersion = (v, vs, t) => ({
-        version: resolve(exports.yamlInputs[v].default, vs, t, os),
+        version: resolve(exports.yamlInputs[v].default, vs, t, os, false),
         supported: vs
     });
     return {
@@ -50,15 +50,16 @@ function getDefaults(os) {
     };
 }
 exports.getDefaults = getDefaults;
-// Side effect: if resolution isn't the identity, print what resolved to what.
-function resolve(version, supported, tool, os) {
+// E.g. resolve ghc latest to 9.4.2
+function resolve(version, supported, tool, os, verbose // If resolution isn't the identity, print what resolved to what.
+) {
     const resolved = version === 'latest'
         ? supported[0]
         : supported.find(v => v.startsWith(version)) ?? version;
     const result = exports.release_revisions?.[os]?.[tool]?.find(({ from }) => from === resolved)?.to ??
         resolved;
     // Andreas 2022-12-29, issue #144: inform about resolution here where we can also output ${tool}.
-    if (version !== result)
+    if (verbose && version !== result)
         core.info(`Resolved ${tool} ${version} to ${result}`);
     return result;
 }
@@ -87,26 +88,22 @@ function getOpts({ ghc, cabal, stack }, os, inputs) {
     const opts = {
         ghc: {
             raw: verInpt.ghc,
-            resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os),
+            resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os, true),
             enable: !stackNoGlobal
         },
         cabal: {
             raw: verInpt.cabal,
-            resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os),
+            resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os, true),
             enable: !stackNoGlobal
         },
         stack: {
             raw: verInpt.stack,
-            resolved: resolve(verInpt.stack, stack.supported, 'stack', os),
+            resolved: resolve(verInpt.stack, stack.supported, 'stack', os, true),
             enable: stackEnable,
             setup: stackSetupGhc
         },
         general: { matcher: { enable: !matcherDisable } }
     };
-    // // eslint-disable-next-line github/array-foreach
-    // Object.values(opts)
-    //   .filter(t => t.enable && t.raw !== t.resolved)
-    //   .forEach(t => core.info(`Resolved ${t.raw} to ${t.resolved}`));
     core.debug(`Options are: ${JSON.stringify(opts)}`);
     return opts;
 }

--- a/setup/lib/opts.js
+++ b/setup/lib/opts.js
@@ -85,20 +85,25 @@ function getOpts({ ghc, cabal, stack }, os, inputs) {
     if (errors.length > 0) {
         throw new Error(errors.join('\n'));
     }
+    const ghcEnable = !stackNoGlobal;
+    const cabalEnable = !stackNoGlobal;
     const opts = {
         ghc: {
             raw: verInpt.ghc,
-            resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os, true),
-            enable: !stackNoGlobal
+            resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os, ghcEnable // if true: inform user about resolution
+            ),
+            enable: ghcEnable
         },
         cabal: {
             raw: verInpt.cabal,
-            resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os, true),
-            enable: !stackNoGlobal
+            resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os, cabalEnable // if true: inform user about resolution
+            ),
+            enable: cabalEnable
         },
         stack: {
             raw: verInpt.stack,
-            resolved: resolve(verInpt.stack, stack.supported, 'stack', os, true),
+            resolved: resolve(verInpt.stack, stack.supported, 'stack', os, stackEnable // if true: inform user about resolution
+            ),
             enable: stackEnable,
             setup: stackSetupGhc
         },

--- a/setup/lib/opts.js
+++ b/setup/lib/opts.js
@@ -50,12 +50,17 @@ function getDefaults(os) {
     };
 }
 exports.getDefaults = getDefaults;
+// Side effect: if resolution isn't the identity, print what resolved to what.
 function resolve(version, supported, tool, os) {
     const resolved = version === 'latest'
         ? supported[0]
         : supported.find(v => v.startsWith(version)) ?? version;
-    return (exports.release_revisions?.[os]?.[tool]?.find(({ from }) => from === resolved)?.to ??
-        resolved);
+    const result = exports.release_revisions?.[os]?.[tool]?.find(({ from }) => from === resolved)?.to ??
+        resolved;
+    // Andreas 2022-12-29, issue #144: inform about resolution here where we can also output ${tool}.
+    if (version !== result)
+        core.info(`Resolved ${tool} ${version} to ${result}`);
+    return result;
 }
 function getOpts({ ghc, cabal, stack }, os, inputs) {
     core.debug(`Inputs are: ${JSON.stringify(inputs)}`);
@@ -98,10 +103,10 @@ function getOpts({ ghc, cabal, stack }, os, inputs) {
         },
         general: { matcher: { enable: !matcherDisable } }
     };
-    // eslint-disable-next-line github/array-foreach
-    Object.values(opts)
-        .filter(t => t.enable && t.raw !== t.resolved)
-        .forEach(t => core.info(`Resolved ${t.raw} to ${t.resolved}`));
+    // // eslint-disable-next-line github/array-foreach
+    // Object.values(opts)
+    //   .filter(t => t.enable && t.raw !== t.resolved)
+    //   .forEach(t => core.info(`Resolved ${t.raw} to ${t.resolved}`));
     core.debug(`Options are: ${JSON.stringify(opts)}`);
     return opts;
 }

--- a/setup/lib/opts.js
+++ b/setup/lib/opts.js
@@ -59,7 +59,7 @@ function resolve(version, supported, tool, os, verbose // If resolution isn't th
     const result = exports.release_revisions?.[os]?.[tool]?.find(({ from }) => from === resolved)?.to ??
         resolved;
     // Andreas 2022-12-29, issue #144: inform about resolution here where we can also output ${tool}.
-    if (verbose && version !== result)
+    if (verbose === true && version !== result)
         core.info(`Resolved ${tool} ${version} to ${result}`);
     return result;
 }

--- a/setup/src/opts.ts
+++ b/setup/src/opts.ts
@@ -56,6 +56,7 @@ export function getDefaults(os: OS): Defaults {
   };
 }
 
+// Side effect: if resolution isn't the identity, print what resolved to what.
 function resolve(
   version: string,
   supported: string[],
@@ -66,10 +67,12 @@ function resolve(
     version === 'latest'
       ? supported[0]
       : supported.find(v => v.startsWith(version)) ?? version;
-  return (
+  const result =
     release_revisions?.[os]?.[tool]?.find(({from}) => from === resolved)?.to ??
-    resolved
-  );
+    resolved;
+  // Andreas 2022-12-29, issue #144: inform about resolution here where we can also output ${tool}.
+  if (version !== result) core.info(`Resolved ${tool} ${version} to ${result}`);
+  return result;
 }
 
 export function getOpts(
@@ -122,10 +125,10 @@ export function getOpts(
     general: {matcher: {enable: !matcherDisable}}
   };
 
-  // eslint-disable-next-line github/array-foreach
-  Object.values(opts)
-    .filter(t => t.enable && t.raw !== t.resolved)
-    .forEach(t => core.info(`Resolved ${t.raw} to ${t.resolved}`));
+  // // eslint-disable-next-line github/array-foreach
+  // Object.values(opts)
+  //   .filter(t => t.enable && t.raw !== t.resolved)
+  //   .forEach(t => core.info(`Resolved ${t.raw} to ${t.resolved}`));
 
   core.debug(`Options are: ${JSON.stringify(opts)}`);
   return opts;

--- a/setup/src/opts.ts
+++ b/setup/src/opts.ts
@@ -72,7 +72,7 @@ function resolve(
     release_revisions?.[os]?.[tool]?.find(({from}) => from === resolved)?.to ??
     resolved;
   // Andreas 2022-12-29, issue #144: inform about resolution here where we can also output ${tool}.
-  if (verbose && version !== result)
+  if (verbose === true && version !== result)
     core.info(`Resolved ${tool} ${version} to ${result}`);
   return result;
 }

--- a/setup/src/opts.ts
+++ b/setup/src/opts.ts
@@ -44,7 +44,7 @@ export const yamlInputs: Record<string, {default: string}> = (
 
 export function getDefaults(os: OS): Defaults {
   const mkVersion = (v: string, vs: string[], t: Tool): Version => ({
-    version: resolve(yamlInputs[v].default, vs, t, os),
+    version: resolve(yamlInputs[v].default, vs, t, os, false), // verbose=false: no printout here
     supported: vs
   });
 
@@ -56,12 +56,13 @@ export function getDefaults(os: OS): Defaults {
   };
 }
 
-// Side effect: if resolution isn't the identity, print what resolved to what.
+// E.g. resolve ghc latest to 9.4.2
 function resolve(
   version: string,
   supported: string[],
   tool: Tool,
-  os: OS
+  os: OS,
+  verbose: boolean // If resolution isn't the identity, print what resolved to what.
 ): string {
   const resolved =
     version === 'latest'
@@ -71,7 +72,8 @@ function resolve(
     release_revisions?.[os]?.[tool]?.find(({from}) => from === resolved)?.to ??
     resolved;
   // Andreas 2022-12-29, issue #144: inform about resolution here where we can also output ${tool}.
-  if (version !== result) core.info(`Resolved ${tool} ${version} to ${result}`);
+  if (verbose && version !== result)
+    core.info(`Resolved ${tool} ${version} to ${result}`);
   return result;
 }
 
@@ -108,27 +110,22 @@ export function getOpts(
   const opts: Options = {
     ghc: {
       raw: verInpt.ghc,
-      resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os),
+      resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os, true), // verbose=true: inform user
       enable: !stackNoGlobal
     },
     cabal: {
       raw: verInpt.cabal,
-      resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os),
+      resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os, true), // verbose=true: inform user
       enable: !stackNoGlobal
     },
     stack: {
       raw: verInpt.stack,
-      resolved: resolve(verInpt.stack, stack.supported, 'stack', os),
+      resolved: resolve(verInpt.stack, stack.supported, 'stack', os, true), // verbose=true: inform user
       enable: stackEnable,
       setup: stackSetupGhc
     },
     general: {matcher: {enable: !matcherDisable}}
   };
-
-  // // eslint-disable-next-line github/array-foreach
-  // Object.values(opts)
-  //   .filter(t => t.enable && t.raw !== t.resolved)
-  //   .forEach(t => core.info(`Resolved ${t.raw} to ${t.resolved}`));
 
   core.debug(`Options are: ${JSON.stringify(opts)}`);
   return opts;

--- a/setup/src/opts.ts
+++ b/setup/src/opts.ts
@@ -107,20 +107,40 @@ export function getOpts(
     throw new Error(errors.join('\n'));
   }
 
+  const ghcEnable = !stackNoGlobal;
+  const cabalEnable = !stackNoGlobal;
   const opts: Options = {
     ghc: {
       raw: verInpt.ghc,
-      resolved: resolve(verInpt.ghc, ghc.supported, 'ghc', os, true), // verbose=true: inform user
-      enable: !stackNoGlobal
+      resolved: resolve(
+        verInpt.ghc,
+        ghc.supported,
+        'ghc',
+        os,
+        ghcEnable // if true: inform user about resolution
+      ),
+      enable: ghcEnable
     },
     cabal: {
       raw: verInpt.cabal,
-      resolved: resolve(verInpt.cabal, cabal.supported, 'cabal', os, true), // verbose=true: inform user
-      enable: !stackNoGlobal
+      resolved: resolve(
+        verInpt.cabal,
+        cabal.supported,
+        'cabal',
+        os,
+        cabalEnable // if true: inform user about resolution
+      ),
+      enable: cabalEnable
     },
     stack: {
       raw: verInpt.stack,
-      resolved: resolve(verInpt.stack, stack.supported, 'stack', os, true), // verbose=true: inform user
+      resolved: resolve(
+        verInpt.stack,
+        stack.supported,
+        'stack',
+        os,
+        stackEnable // if true: inform user about resolution
+      ),
       enable: stackEnable,
       setup: stackSetupGhc
     },


### PR DESCRIPTION
Fix #144: Instead of just printing e.g. `Resolved latest to 2.9.3`, print `Resolved stack latest to 2.9.3`.

E.g.: https://github.com/haskell/actions/actions/runs/3757986267/jobs/6385794767#step:3:7
```
Preparing to setup a Haskell environment
Resolved latest to 9.4.2
Resolved latest to 3.8.1.0
```

With this PR: https://github.com/haskell/actions/actions/runs/3794946311/jobs/6453551975#step:3:7
```
Preparing to setup a Haskell environment
Resolved ghc latest to 9.4.2
Resolved cabal latest to 3.8.1.0
```
