### PR TITLE
Add a new workflow to generate release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: "/release"
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')  # only run on "releases" (pushes to tags)
+    steps:
+    - uses: actions/checkout@v3
+    - run: git show HEAD --format='%s%n%n%b' -s > .release_body
+    - uses: softprops/action-gh-release@v1
+      with:
+        generate_release_notes: true
+        body_path: .release_body

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: "/release"
 on:
-  workflow_dispatch:
   push:
     tags:
       - v*.*.*


### PR DESCRIPTION
This way, when running `git push --tags`, after appropriately tagging a commit as `vx.y.z`, a GitHub release page will be created titled `vx.y.z` (that is, the name of the tag) and with two pieces of contents:

- the title and body of the tagged commit. This assumes that the commit message is properly sanitized, so its inclusion in the release page is worthwhile and/or informative
- the changelog since the last tag, assuming semver

GitHub gives a higher priority to releases than to tags. Releases show up on the side of the repository, can have special triggers for workflows, can be subscribed to (so that downstream users will know to update). The last item is especially relevant since dependency update bots (e.g., Dependabot) can be configured to look for releases of GitHub actions used in the workflows of a repository and update them when these change. This is especially useful if the upstream actions are pinned by hash instead of by short tag name (as recommended by supply-chain security best guidelines -- not implemented here, as the goal is to follow the setup of the other actions).

Tested on https://github.com/mihaimaruseac/actions/releases

Prompted by discussion on https://github.com/haskell/actions/pull/148, after closing.

Signed-off-by: Mihai Maruseac <mihai.maruseac@gmail.com>