### PR TITLE
Fix #130: ensure cabal installdir is in the PATH

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -78,6 +78,11 @@ jobs:
           cabal-version: ${{ matrix.cabal }}
           cabal-update: ${{ matrix.cabal_update }}
 
+      - name: Show installed versions
+        run: |
+          cabal --version
+          ghc --version
+
       - name: Test runghc
         run: |
           runghc --version
@@ -91,15 +96,18 @@ jobs:
         working-directory: setup/__tests__/project
         run: cabal run
 
+      - name: Install test project
+        working-directory: setup/__tests__/project
+        run: cabal install
+
+      - name: Run installed test project
+        run: hello-haskell-setup
+        # This tests whether the default installdir has been added to the PATH (issue #130).
+
       - name: Build and run test with Hackage dependency
         if:   ${{ matrix.cabal_update != 'false' }}
         working-directory: setup/__tests__/project-with-hackage-dependency
         run:  cabal build && cabal run
-
-      - name: Show installed versions
-        run: |
-          cabal --version
-          ghc --version
 
       - name: Confirm installed and expected versions match
         shell: bash

--- a/setup/__tests__/project/project.cabal
+++ b/setup/__tests__/project/project.cabal
@@ -3,7 +3,7 @@ name:                project
 version:             0.1.0.0
 build-type:          Simple
 
-executable project
+executable hello-haskell-setup
   main-is:             Main.hs
   build-depends:       base
   default-language:    Haskell2010

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13850,7 +13850,9 @@ async function run(inputs) {
                 else {
                     core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
                     // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
-                    core.addPath(`${process.env.HOME}/.cabal/bin`);
+                    const installdir = `${process.env.HOME}/.cabal/bin`;
+                    core.info(`Adding ${installdir} to PATH`);
+                    core.addPath(installdir);
                 }
                 // Workaround the GHC nopie linking errors for ancient GHC versions
                 // NB: Is this _just_ for GHC 7.10.3?

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13849,6 +13849,8 @@ async function run(inputs) {
                 }
                 else {
                     core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
+                    // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
+                    core.addPath(`${process.env.HOME}/.cabal/bin`);
                 }
                 // Workaround the GHC nopie linking errors for ancient GHC versions
                 // NB: Is this _just_ for GHC 7.10.3?

--- a/setup/lib/setup-haskell.js
+++ b/setup/lib/setup-haskell.js
@@ -70,6 +70,8 @@ async function run(inputs) {
                 }
                 else {
                     core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
+                    // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
+                    core.addPath(`${process.env.HOME}/.cabal/bin`);
                 }
                 // Workaround the GHC nopie linking errors for ancient GHC versions
                 // NB: Is this _just_ for GHC 7.10.3?

--- a/setup/lib/setup-haskell.js
+++ b/setup/lib/setup-haskell.js
@@ -71,7 +71,9 @@ async function run(inputs) {
                 else {
                     core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
                     // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
-                    core.addPath(`${process.env.HOME}/.cabal/bin`);
+                    const installdir = `${process.env.HOME}/.cabal/bin`;
+                    core.info(`Adding ${installdir} to PATH`);
+                    core.addPath(installdir);
                 }
                 // Workaround the GHC nopie linking errors for ancient GHC versions
                 // NB: Is this _just_ for GHC 7.10.3?

--- a/setup/src/setup-haskell.ts
+++ b/setup/src/setup-haskell.ts
@@ -58,7 +58,9 @@ export default async function run(
         } else {
           core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
           // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
-          core.addPath(`${process.env.HOME}/.cabal/bin`);
+          const installdir = `${process.env.HOME}/.cabal/bin`;
+          core.info(`Adding ${installdir} to PATH`);
+          core.addPath(installdir);
         }
 
         // Workaround the GHC nopie linking errors for ancient GHC versions

--- a/setup/src/setup-haskell.ts
+++ b/setup/src/setup-haskell.ts
@@ -57,6 +57,8 @@ export default async function run(
           core.setOutput('cabal-store', 'C:\\sr');
         } else {
           core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
+          // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
+          core.addPath(`${process.env.HOME}/.cabal/bin`);
         }
 
         // Workaround the GHC nopie linking errors for ancient GHC versions


### PR DESCRIPTION
Fix #130: ensure cabal installdir (typically `~/.cabal/bin`) is added to the PATH.

This is now tested in CI via a `cabal install` with subsequent call to the installed executable.