### PR TITLE
Re #202: choco install ghc --ignore-dependencies

### DIFF
--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13511,6 +13511,7 @@ async function choco(tool, version) {
         tool,
         '--version',
         revision,
+        '--allow-multiple-versions',
         // Andreas, 2023-03-13, issue #202:
         // When installing GHC, skip automatic cabal installation.
         tool == 'ghc' ? '--ignore-dependencies' : '',
@@ -13854,19 +13855,20 @@ async function run(inputs) {
         if (opts.ghcup.releaseChannel) {
             await core.group(`Preparing ghcup environment`, async () => (0, installer_1.addGhcupReleaseChannel)(opts.ghcup.releaseChannel, os));
         }
-        // Andreas, 2023-03-13, issue #202: Prepare choco.
-        // Since currently choco is the only install method for Windows,
-        // the following test is ok.
-        if (os == 'win32')
-            // choco install chocolatey-core.extension
-            await (0, exec_1.exec)('powershell', [
-                'choco',
-                'install',
-                'chocolatey-core.extension',
-                // Verbosity options:
-                '--no-progress',
-                core.isDebug() ? '--debug' : '--limit-output'
-            ]);
+        // NOT NEEDED
+        // // Andreas, 2023-03-13, issue #202: Prepare choco.
+        // // Since currently choco is the only install method for Windows,
+        // // the following test is ok.
+        // if (os == 'win32')
+        //   // choco install chocolatey-core.extension
+        //   await exec('powershell', [
+        //     'choco',
+        //     'install',
+        //     'chocolatey-core.extension',
+        //     // Verbosity options:
+        //     '--no-progress',
+        //     core.isDebug() ? '--debug' : '--limit-output'
+        //   ]);
         for (const [t, { resolved }] of Object.entries(opts).filter(o => o[1].enable)) {
             await core.group(`Preparing ${t} environment`, async () => (0, installer_1.resetTool)(t, resolved, os));
             await core.group(`Installing ${t} version ${resolved}`, async () => (0, installer_1.installTool)(t, resolved, os));

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13511,9 +13511,12 @@ async function choco(tool, version) {
         tool,
         '--version',
         revision,
-        '-m',
+        // Andreas, 2023-03-13, issue #202:
+        // When installing GHC, skip automatic cabal installation.
+        tool == 'ghc' ? '--ignore-dependencies' : '',
+        // Verbosity options:
         '--no-progress',
-        core.isDebug() ? '-d' : '-r'
+        core.isDebug() ? '--debug' : '--limit-output'
     ];
     if ((await exec('powershell', args)) !== 0)
         await exec('powershell', [...args, '--pre']);
@@ -13851,6 +13854,19 @@ async function run(inputs) {
         if (opts.ghcup.releaseChannel) {
             await core.group(`Preparing ghcup environment`, async () => (0, installer_1.addGhcupReleaseChannel)(opts.ghcup.releaseChannel, os));
         }
+        // Andreas, 2023-03-13, issue #202: Prepare choco.
+        // Since currently choco is the only install method for Windows,
+        // the following test is ok.
+        if (os == 'win32')
+            // choco install chocolatey-core.extension
+            await (0, exec_1.exec)('powershell', [
+                'choco',
+                'install',
+                'chocolatey-core.extension',
+                // Verbosity options:
+                '--no-progress',
+                core.isDebug() ? '--debug' : '--limit-output'
+            ]);
         for (const [t, { resolved }] of Object.entries(opts).filter(o => o[1].enable)) {
             await core.group(`Preparing ${t} environment`, async () => (0, installer_1.resetTool)(t, resolved, os));
             await core.group(`Installing ${t} version ${resolved}`, async () => (0, installer_1.installTool)(t, resolved, os));

--- a/setup/lib/installer.js
+++ b/setup/lib/installer.js
@@ -234,9 +234,12 @@ async function choco(tool, version) {
         tool,
         '--version',
         revision,
-        '-m',
+        // Andreas, 2023-03-13, issue #202:
+        // When installing GHC, skip automatic cabal installation.
+        tool == 'ghc' ? '--ignore-dependencies' : '',
+        // Verbosity options:
         '--no-progress',
-        core.isDebug() ? '-d' : '-r'
+        core.isDebug() ? '--debug' : '--limit-output'
     ];
     if ((await exec('powershell', args)) !== 0)
         await exec('powershell', [...args, '--pre']);

--- a/setup/lib/installer.js
+++ b/setup/lib/installer.js
@@ -234,6 +234,7 @@ async function choco(tool, version) {
         tool,
         '--version',
         revision,
+        '--allow-multiple-versions',
         // Andreas, 2023-03-13, issue #202:
         // When installing GHC, skip automatic cabal installation.
         tool == 'ghc' ? '--ignore-dependencies' : '',

--- a/setup/lib/setup-haskell.js
+++ b/setup/lib/setup-haskell.js
@@ -51,19 +51,20 @@ async function run(inputs) {
         if (opts.ghcup.releaseChannel) {
             await core.group(`Preparing ghcup environment`, async () => (0, installer_1.addGhcupReleaseChannel)(opts.ghcup.releaseChannel, os));
         }
-        // Andreas, 2023-03-13, issue #202: Prepare choco.
-        // Since currently choco is the only install method for Windows,
-        // the following test is ok.
-        if (os == 'win32')
-            // choco install chocolatey-core.extension
-            await (0, exec_1.exec)('powershell', [
-                'choco',
-                'install',
-                'chocolatey-core.extension',
-                // Verbosity options:
-                '--no-progress',
-                core.isDebug() ? '--debug' : '--limit-output'
-            ]);
+        // NOT NEEDED
+        // // Andreas, 2023-03-13, issue #202: Prepare choco.
+        // // Since currently choco is the only install method for Windows,
+        // // the following test is ok.
+        // if (os == 'win32')
+        //   // choco install chocolatey-core.extension
+        //   await exec('powershell', [
+        //     'choco',
+        //     'install',
+        //     'chocolatey-core.extension',
+        //     // Verbosity options:
+        //     '--no-progress',
+        //     core.isDebug() ? '--debug' : '--limit-output'
+        //   ]);
         for (const [t, { resolved }] of Object.entries(opts).filter(o => o[1].enable)) {
             await core.group(`Preparing ${t} environment`, async () => (0, installer_1.resetTool)(t, resolved, os));
             await core.group(`Installing ${t} version ${resolved}`, async () => (0, installer_1.installTool)(t, resolved, os));

--- a/setup/lib/setup-haskell.js
+++ b/setup/lib/setup-haskell.js
@@ -51,6 +51,19 @@ async function run(inputs) {
         if (opts.ghcup.releaseChannel) {
             await core.group(`Preparing ghcup environment`, async () => (0, installer_1.addGhcupReleaseChannel)(opts.ghcup.releaseChannel, os));
         }
+        // Andreas, 2023-03-13, issue #202: Prepare choco.
+        // Since currently choco is the only install method for Windows,
+        // the following test is ok.
+        if (os == 'win32')
+            // choco install chocolatey-core.extension
+            await (0, exec_1.exec)('powershell', [
+                'choco',
+                'install',
+                'chocolatey-core.extension',
+                // Verbosity options:
+                '--no-progress',
+                core.isDebug() ? '--debug' : '--limit-output'
+            ]);
         for (const [t, { resolved }] of Object.entries(opts).filter(o => o[1].enable)) {
             await core.group(`Preparing ${t} environment`, async () => (0, installer_1.resetTool)(t, resolved, os));
             await core.group(`Installing ${t} version ${resolved}`, async () => (0, installer_1.installTool)(t, resolved, os));

--- a/setup/src/installer.ts
+++ b/setup/src/installer.ts
@@ -273,6 +273,7 @@ async function choco(tool: Tool, version: string): Promise<void> {
     tool,
     '--version',
     revision,
+    '--allow-multiple-versions',
     // Andreas, 2023-03-13, issue #202:
     // When installing GHC, skip automatic cabal installation.
     tool == 'ghc' ? '--ignore-dependencies' : '',

--- a/setup/src/installer.ts
+++ b/setup/src/installer.ts
@@ -273,9 +273,12 @@ async function choco(tool: Tool, version: string): Promise<void> {
     tool,
     '--version',
     revision,
-    '-m',
+    // Andreas, 2023-03-13, issue #202:
+    // When installing GHC, skip automatic cabal installation.
+    tool == 'ghc' ? '--ignore-dependencies' : '',
+    // Verbosity options:
     '--no-progress',
-    core.isDebug() ? '-d' : '-r'
+    core.isDebug() ? '--debug' : '--limit-output'
   ];
   if ((await exec('powershell', args)) !== 0)
     await exec('powershell', [...args, '--pre']);

--- a/setup/src/setup-haskell.ts
+++ b/setup/src/setup-haskell.ts
@@ -32,19 +32,20 @@ export default async function run(
       );
     }
 
-    // Andreas, 2023-03-13, issue #202: Prepare choco.
-    // Since currently choco is the only install method for Windows,
-    // the following test is ok.
-    if (os == 'win32')
-      // choco install chocolatey-core.extension
-      await exec('powershell', [
-        'choco',
-        'install',
-        'chocolatey-core.extension',
-        // Verbosity options:
-        '--no-progress',
-        core.isDebug() ? '--debug' : '--limit-output'
-      ]);
+    // NOT NEEDED
+    // // Andreas, 2023-03-13, issue #202: Prepare choco.
+    // // Since currently choco is the only install method for Windows,
+    // // the following test is ok.
+    // if (os == 'win32')
+    //   // choco install chocolatey-core.extension
+    //   await exec('powershell', [
+    //     'choco',
+    //     'install',
+    //     'chocolatey-core.extension',
+    //     // Verbosity options:
+    //     '--no-progress',
+    //     core.isDebug() ? '--debug' : '--limit-output'
+    //   ]);
 
     for (const [t, {resolved}] of Object.entries(opts).filter(
       o => o[1].enable

--- a/setup/src/setup-haskell.ts
+++ b/setup/src/setup-haskell.ts
@@ -32,6 +32,20 @@ export default async function run(
       );
     }
 
+    // Andreas, 2023-03-13, issue #202: Prepare choco.
+    // Since currently choco is the only install method for Windows,
+    // the following test is ok.
+    if (os == 'win32')
+      // choco install chocolatey-core.extension
+      await exec('powershell', [
+        'choco',
+        'install',
+        'chocolatey-core.extension',
+        // Verbosity options:
+        '--no-progress',
+        core.isDebug() ? '--debug' : '--limit-output'
+      ]);
+
     for (const [t, {resolved}] of Object.entries(opts).filter(
       o => o[1].enable
     )) {


### PR DESCRIPTION
Following recipe given by @Mistuke in https://github.com/haskell/actions/issues/202#issuecomment-1465822109 :
```
choco install chocolatey-core.extension
choco install ghc --ignore-dependencies
choco install cabal
```