### PR TITLE
Fix #210: set `store-dir` in `.cabal/config` to dodge cabal 3.10 XDG

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,6 +59,13 @@ jobs:
 
         include:
 
+          # Test #210 (XDG): is the cabal store-dir set to something meaningful?
+          - os:  ubuntu-latest
+            plan:
+              ghc:   "9.6"
+              cabal: "3.10"
+            cabal_update: "true"
+
           # Test some old versions
           - os: ubuntu-latest
             plan:

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13834,6 +13834,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
+const io = __importStar(__nccwpck_require__(7436));
 const ensure_error_1 = __importDefault(__nccwpck_require__(1056));
 const fs = __importStar(__nccwpck_require__(7147));
 const path = __importStar(__nccwpck_require__(1017));
@@ -13866,6 +13867,10 @@ async function run(inputs) {
             await core.group('Pre-installing GHC with stack', async () => (0, exec_1.exec)('stack', ['setup', opts.ghc.resolved]));
         if (opts.cabal.enable)
             await core.group('Setting up cabal', async () => {
+                // Andreas, 2023-03-16, issue #210.
+                // Create .cabal/bin to activate non-XDG mode of cabal.
+                if (process.platform !== 'win32')
+                    io.mkdirP(`${process.env.HOME}/.cabal/bin`);
                 // Create config only if it doesn't exist.
                 await (0, exec_1.exec)('cabal', ['user-config', 'init'], {
                     silent: true,

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13871,16 +13871,17 @@ async function run(inputs) {
                     silent: true,
                     ignoreReturnCode: true
                 });
+                // Set the 'store-dir' in the cabal configuration.
                 // Blindly appending is fine.
                 // Cabal merges these and picks the last defined option.
                 const configFile = await cabalConfig();
-                if (process.platform === 'win32') {
-                    fs.appendFileSync(configFile, `store-dir: C:\\sr${os_1.EOL}`);
-                    core.setOutput('cabal-store', 'C:\\sr');
-                }
-                else {
-                    core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
-                    // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
+                const storeDir = process.platform === 'win32'
+                    ? 'C:\\sr'
+                    : `${process.env.HOME}/.cabal/store`;
+                fs.appendFileSync(configFile, `store-dir: ${storeDir}${os_1.EOL}`);
+                core.setOutput('cabal-store', storeDir);
+                // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
+                if (process.platform !== 'win32') {
                     const installdir = `${process.env.HOME}/.cabal/bin`;
                     core.info(`Adding ${installdir} to PATH`);
                     core.addPath(installdir);

--- a/setup/lib/setup-haskell.js
+++ b/setup/lib/setup-haskell.js
@@ -64,16 +64,17 @@ async function run(inputs) {
                     silent: true,
                     ignoreReturnCode: true
                 });
+                // Set the 'store-dir' in the cabal configuration.
                 // Blindly appending is fine.
                 // Cabal merges these and picks the last defined option.
                 const configFile = await cabalConfig();
-                if (process.platform === 'win32') {
-                    fs.appendFileSync(configFile, `store-dir: C:\\sr${os_1.EOL}`);
-                    core.setOutput('cabal-store', 'C:\\sr');
-                }
-                else {
-                    core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
-                    // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
+                const storeDir = process.platform === 'win32'
+                    ? 'C:\\sr'
+                    : `${process.env.HOME}/.cabal/store`;
+                fs.appendFileSync(configFile, `store-dir: ${storeDir}${os_1.EOL}`);
+                core.setOutput('cabal-store', storeDir);
+                // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
+                if (process.platform !== 'win32') {
                     const installdir = `${process.env.HOME}/.cabal/bin`;
                     core.info(`Adding ${installdir} to PATH`);
                     core.addPath(installdir);

--- a/setup/lib/setup-haskell.js
+++ b/setup/lib/setup-haskell.js
@@ -27,6 +27,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
+const io = __importStar(require("@actions/io"));
 const ensure_error_1 = __importDefault(require("ensure-error"));
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
@@ -59,6 +60,10 @@ async function run(inputs) {
             await core.group('Pre-installing GHC with stack', async () => (0, exec_1.exec)('stack', ['setup', opts.ghc.resolved]));
         if (opts.cabal.enable)
             await core.group('Setting up cabal', async () => {
+                // Andreas, 2023-03-16, issue #210.
+                // Create .cabal/bin to activate non-XDG mode of cabal.
+                if (process.platform !== 'win32')
+                    io.mkdirP(`${process.env.HOME}/.cabal/bin`);
                 // Create config only if it doesn't exist.
                 await (0, exec_1.exec)('cabal', ['user-config', 'init'], {
                     silent: true,

--- a/setup/src/setup-haskell.ts
+++ b/setup/src/setup-haskell.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core';
+import * as io from '@actions/io';
 import ensureError from 'ensure-error';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -50,6 +51,11 @@ export default async function run(
 
     if (opts.cabal.enable)
       await core.group('Setting up cabal', async () => {
+        // Andreas, 2023-03-16, issue #210.
+        // Create .cabal/bin to activate non-XDG mode of cabal.
+        if (process.platform !== 'win32')
+          io.mkdirP(`${process.env.HOME}/.cabal/bin`);
+
         // Create config only if it doesn't exist.
         await exec('cabal', ['user-config', 'init'], {
           silent: true,

--- a/setup/src/setup-haskell.ts
+++ b/setup/src/setup-haskell.ts
@@ -55,15 +55,20 @@ export default async function run(
           silent: true,
           ignoreReturnCode: true
         });
+
+        // Set the 'store-dir' in the cabal configuration.
         // Blindly appending is fine.
         // Cabal merges these and picks the last defined option.
         const configFile = await cabalConfig();
-        if (process.platform === 'win32') {
-          fs.appendFileSync(configFile, `store-dir: C:\\sr${EOL}`);
-          core.setOutput('cabal-store', 'C:\\sr');
-        } else {
-          core.setOutput('cabal-store', `${process.env.HOME}/.cabal/store`);
-          // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
+        const storeDir =
+          process.platform === 'win32'
+            ? 'C:\\sr'
+            : `${process.env.HOME}/.cabal/store`;
+        fs.appendFileSync(configFile, `store-dir: ${storeDir}${EOL}`);
+        core.setOutput('cabal-store', storeDir);
+
+        // Issue #130: for non-choco installs, add ~/.cabal/bin to PATH
+        if (process.platform !== 'win32') {
           const installdir = `${process.env.HOME}/.cabal/bin`;
           core.info(`Adding ${installdir} to PATH`);
           core.addPath(installdir);


### PR DESCRIPTION
We set the `store-dir` (`outputs.cabal-store`) explicitly in the cabal configuration file because cabal 3.10 has some context-dependent default for it: If `~/.cabal` is not present, it uses the new XDG layout, otherwise the legacy layout.

Update: Also need to create `~/.cabal` to avoid XDG fallback, so we create `~/.cabal/bin`.  Likely this makes the "set `store-dir`" patch obsolete, but we keep it for uniformity (it anyway happens on Windows, now on all platforms).

Closes #210.
- #210