### PR TITLE
Add code scanning action with HLint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Collection of GitHub actions for interacting with Haskell.
 | [`haskell/actions/setup`](./setup)             |
 | [`haskell/actions/hlint-setup`](./hlint-setup) |
 | [`haskell/actions/hlint-run`](./hlint-run)     |
+| [`haskell/actions/hlint-scan`](./hlint-scan)   |
 |                                                |
 
 See the individual action directory for details on usage and examples.

--- a/hlint-scan/README.md
+++ b/hlint-scan/README.md
@@ -1,0 +1,63 @@
+# haskell/actions/hlint-scan
+
+This action scans Haskell code using [HLint] and uploads its suggested improvements to [GitHub code scanning].
+
+This needs HLint to be set up.  This can be taken care of by [haskell/actions/hlint-setup](../hlint-setup/).
+
+[HLint]: https://github.com/ndmitchell/hlint
+[GitHub code scanning]: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning
+
+## Usage
+
+A minimual example for setting up code scanning with HLint:
+
+```yaml
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  scan:
+    name: Scan code with HLint
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload results to GitHub code scanning.
+      security-events: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/hlint-setup@v2
+      - uses: haskell/actions/hlint-scan@v2
+```
+
+### Inputs
+
+None of the inputs are required.  You only need to set them if the defaults do not work for your situation.
+
+`hlint-bin`
+:   Path to the hlint binary.
+
+`args`
+:   Extra arguments to pass to HLint.
+
+`path`
+:   Path or array of paths that HLint will be told to scan.
+
+`sarif_file`
+:   The name of the SARIF file to write and upload to GItHub code scanning.
+
+`category`
+:   String used by GitHub code scanning for matching the analyses.
+
+### Outputs
+
+`sarif-id`
+:   The ID of the uploaded SARIF file.
+
+## Note
+
+This does not fail the workflow when HLint finds any code which could be improved.
+In other words, this action is not intended to be used as a status check.
+Instead, its goal is to file [GitHub code scanning] alerts.
+
+To use HLint for status checks, e.g., during pushes or pull requests,
+see [haskell/actions/hlint-run](../hlint-run/) instead.

--- a/hlint-scan/action.yaml
+++ b/hlint-scan/action.yaml
@@ -1,0 +1,45 @@
+name: Scan code with HLint
+description: Scan Haskell code for possible improvements using HLint.
+
+inputs:
+  hlint-bin:
+    description: Path to the hlint binary.
+    required: false
+    default: hlint
+  args:
+    description: Extra arguments to pass to HLint.
+    required: false
+    default: null
+  path:
+    description: Path or array of paths that HLint will be told to scan.
+    required: false
+    default: .
+  sarif_file:
+    description: The name of the SARIF file to write and upload to GItHub code scanning.
+    required: false
+    default: hlint.sarif
+  category:
+    description: String used by GitHub code scanning for matching the analyses.
+    required: false
+    default: null
+
+outputs:
+  sarif-id:
+    description: The ID of the uploaded SARIF file.
+    value: ${{ steps.upload-sarif.outputs.sarif-id }}
+
+runs:
+  using: 'composite'
+
+  steps:
+
+    - name: Run HLint
+      run: ${{ inputs.hlint-bin }} --no-exit-code --sarif ${{ join(inputs.path, ' ') }} >> ${{ inputs.sarif_file }}
+      shell: bash
+
+    - id: upload-sarif
+      name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: ${{ inputs.sarif_file }}
+        category: ${{ inputs.category }}


### PR DESCRIPTION
With [SARIF] support now [included](https://github.com/ndmitchell/hlint/pull/1482), HLint can be used as a code scanning tool on GitHub.

This pull request adds a code scanning action using HLint.  It creates a SARIF file with HLint and uploads it to GitHub, which can then put up code scanning alerts in its dashboards.  This is separate from haskell/actions/hlint-run so that code scanning alerts can be dismissed without the underlying reason going away.  I.e., if the alerts are intentionally dismissed, then the workflow shouldn't cause status checks to fail by returning non-zero exit codes.

Code scanning alerts are confirmed to appear for a [test branch](https://github.com/chungyc/actions/security/code-scanning?query=is%3Aopen+branch%3Atest), although I'm not sure if anyone not collaborating directly with the fork can see them.

The relevant change in HLint has yet to be included in an official release, so this pull request will remain in draft until it is.

[SARIF]: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning
