### PR TITLE
Fix #245: call `ghcup unset` if correct tool version was not found.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,6 +12,7 @@ on:
 
 defaults:
   run:
+    shell: bash
     working-directory: setup
 
 jobs:
@@ -129,6 +130,12 @@ jobs:
               ghc:   "9.4.5"
               cabal: "3.8"
 
+          # Test GHC 9.4.4 on windows (Issue #245)
+          - os: windows-latest
+            plan:
+              ghc:   "9.4.4"
+              cabal: "3.10.1.0"
+
     steps:
       - uses: actions/checkout@v3
 
@@ -139,10 +146,11 @@ jobs:
           cabal-version: ${{ matrix.plan.cabal }}
           cabal-update: ${{ matrix.cabal_update }}
 
-      - name: Show installed versions
+      - name: Show installed versions and PATH
         run: |
           cabal --version
           ghc --version
+          echo "$PATH"
 
       - name: Test runghc
         run: |

--- a/setup/dist/index.js
+++ b/setup/dist/index.js
@@ -13405,8 +13405,14 @@ async function isInstalled(tool, version, os) {
                     tool,
                     version
                 ]);
-                if (ghcupSetResult == 0)
+                if (ghcupSetResult == 0) {
                     return success(tool, version, installedPath, os);
+                }
+                else {
+                    // Andreas, 2023-05-03, issue #245.
+                    // Since we do not have the correct version, disable any default version.
+                    await exec(await ghcupBin(os), ['unset', tool]);
+                }
             }
             else {
                 // Install methods apt and choco have precise install paths,

--- a/setup/lib/installer.js
+++ b/setup/lib/installer.js
@@ -124,8 +124,14 @@ async function isInstalled(tool, version, os) {
                     tool,
                     version
                 ]);
-                if (ghcupSetResult == 0)
+                if (ghcupSetResult == 0) {
                     return success(tool, version, installedPath, os);
+                }
+                else {
+                    // Andreas, 2023-05-03, issue #245.
+                    // Since we do not have the correct version, disable any default version.
+                    await exec(await ghcupBin(os), ['unset', tool]);
+                }
             }
             else {
                 // Install methods apt and choco have precise install paths,

--- a/setup/src/installer.ts
+++ b/setup/src/installer.ts
@@ -130,8 +130,13 @@ async function isInstalled(
           tool,
           version
         ]);
-        if (ghcupSetResult == 0)
+        if (ghcupSetResult == 0) {
           return success(tool, version, installedPath, os);
+        } else {
+          // Andreas, 2023-05-03, issue #245.
+          // Since we do not have the correct version, disable any default version.
+          await exec(await ghcupBin(os), ['unset', tool]);
+        }
       } else {
         // Install methods apt and choco have precise install paths,
         // so if the install path is present, the tool should be present, too.


### PR DESCRIPTION
Fix #245: call `ghcup unset` if correct tool version was not found.