### PR TITLE
add explicit coercion where TypeSsript 5 became more strict

### DIFF
--- a/hlint-run/package.json
+++ b/hlint-run/package.json
@@ -33,6 +33,6 @@
   "devDependencies": {
     "@types/node": "^18.16.3",
     "@vercel/ncc": "^0.36.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.4"
   }
 }

--- a/hlint-run/src/run.ts
+++ b/hlint-run/src/run.ts
@@ -45,7 +45,7 @@ async function runHLint(cmd: string, args: string[]): Promise<HLintResult> {
 function getOverallCheckResult(failOn: CheckMode, {ideas, statusCode}: HLintResult): CheckResult {
   const hintsBySev = HLINT_SEV_LEVELS.map(sev => ([sev, ideas.filter(hint => hint.severity === sev).length]));
   const hintSummary = hintsBySev
-    .filter(([_sevName, numHints]) => numHints > 0)
+    .filter(([_sevName, numHints]) => +numHints > 0)
     .map(([sev, num]) => `${sev} (${num})`).join(', ');
 
   let ok: boolean;
@@ -59,7 +59,7 @@ function getOverallCheckResult(failOn: CheckMode, {ideas, statusCode}: HLintResu
     // Note that the summary still shows all counts.
     const failedBySev = hintsBySev
       .slice(0, HLINT_SEV_LEVELS.indexOf(failOn) + 1)
-      .filter(([_sevName, numHints]) => numHints > 0);
+      .filter(([_sevName, numHints]) => +numHints > 0);
     ok = failedBySev.length === 0;
   }
 

--- a/hlint-run/yarn.lock
+++ b/hlint-run/yarn.lock
@@ -18,16 +18,16 @@
     "@actions/io" "^1.0.1"
 
 "@actions/http-client@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-2.0.1.tgz#873f4ca98fe32f6839462a6f046332677322f99c"
-  integrity sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-2.1.0.tgz#b6d8c3934727d6a50d10d19f00a711a964599a9f"
+  integrity sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==
   dependencies:
     tunnel "^0.0.6"
 
 "@actions/io@^1.0.1", "@actions/io@^1.1.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.1.2.tgz#766ac09674a289ce0f1550ffe0a6eac9261a8ea9"
-  integrity sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.1.3.tgz#4cdb6254da7962b07473ff5c335f3da485d94d71"
+  integrity sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==
 
 "@actions/tool-cache@^2.0.1":
   version "2.0.1"
@@ -42,9 +42,9 @@
     uuid "^3.3.2"
 
 "@types/node@^18.16.3":
-  version "18.16.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.3.tgz#6bda7819aae6ea0b386ebc5b24bdf602f1b42b01"
-  integrity sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==
+  version "18.16.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.9.tgz#e79416d778a8714597342bb87efb5a6e914f7a73"
+  integrity sha512-IeB32oIV4oGArLrd7znD2rkHQ6EDCM+2Sr76dJnrHwv9OHBTTM6nuDLK9bmikXzPa0ZlWMWtRGo/Uw4mrzQedA==
 
 "@vercel/ncc@^0.36.1":
   version "0.36.1"
@@ -61,10 +61,10 @@ tunnel@^0.0.6:
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 uuid@^3.3.2:
   version "3.4.0"


### PR DESCRIPTION
fix #227

The fix is taken from
https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#forbidden-implicit-coercions-in-relational-operators